### PR TITLE
Redesign filter bar layout for desktop

### DIFF
--- a/src/components/filters/hierarchical-region-select.tsx
+++ b/src/components/filters/hierarchical-region-select.tsx
@@ -12,6 +12,11 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
 import { FilterRegion } from "@/types/filter-types"
 
 interface HierarchicalRegionSelectProps {
@@ -20,6 +25,7 @@ interface HierarchicalRegionSelectProps {
   onRegionChange: (regionId: number | null) => void
   placeholder?: string
   className?: string
+  variant?: 'inline' | 'popover'
 }
 
 export function HierarchicalRegionSelect({
@@ -27,6 +33,7 @@ export function HierarchicalRegionSelect({
   selectedRegionId,
   onRegionChange,
   className,
+  variant = 'inline',
 }: HierarchicalRegionSelectProps) {
   const [isExpanded, setIsExpanded] = React.useState(false)
   const [searchValue, setSearchValue] = React.useState("")
@@ -84,106 +91,40 @@ export function HierarchicalRegionSelect({
     ? selectedRegion.name
     : "United Kingdom"
 
-  return (
-    <div className={cn("space-y-2", className)}>
-      {/* Trigger Button */}
-      <Button
-        variant="outline"
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full h-auto py-3 px-4 border rounded-lg justify-between hover:bg-accent/50"
-      >
-        <span className="text-sm font-medium text-foreground">Region</span>
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">{displayValue}</span>
-          <ChevronDown className={cn(
-            "h-4 w-4 shrink-0 opacity-50 transition-transform",
-            isExpanded && "rotate-180"
-          )} />
-        </div>
-      </Button>
+  // Dropdown content component (reused by both variants)
+  const dropdownContent = (
+    <div className="border rounded-lg overflow-hidden bg-background shadow-lg">
+      {/* Search Input */}
+      <div className="p-2 border-b">
+        <Input
+          type="text"
+          placeholder="Search regions..."
+          value={searchValue}
+          onChange={(e) => setSearchValue(e.target.value)}
+          className="h-9"
+        />
+      </div>
 
-      {/* Expanded Content */}
-      {isExpanded && (
-        <div className="border rounded-lg overflow-hidden bg-background">
-          {/* Search Input */}
-          <div className="p-2 border-b">
-            <Input
-              type="text"
-              placeholder="Search regions..."
-              value={searchValue}
-              onChange={(e) => setSearchValue(e.target.value)}
-              className="h-9"
-            />
+      {/* Scrollable Region List */}
+      <div className="max-h-[300px] overflow-y-auto">
+        {filteredGroups.length === 0 ? (
+          <div className="p-4 text-sm text-center text-muted-foreground">
+            No region found.
           </div>
-
-          {/* Scrollable Region List */}
-          <div className="max-h-[300px] overflow-y-auto">
-            {filteredGroups.length === 0 ? (
-              <div className="p-4 text-sm text-center text-muted-foreground">
-                No region found.
-              </div>
-            ) : (
-              <Accordion type="multiple" className="w-full p-2">
-                {filteredGroups.map(({ country, counties }) => (
-                  <AccordionItem key={country.id} value={`country-${country.id}`} className="border-0">
-                    {counties.length > 0 ? (
-                      <>
-                        {/* Country row - split into selection button and accordion trigger */}
-                        <div className="flex items-center">
-                          {/* Country selection button */}
-                          <Button
-                            variant="ghost"
-                            onClick={() => handleRegionSelect(country.id)}
-                            className={cn(
-                              "flex-1 justify-start h-auto py-2 px-3 rounded-none hover:bg-accent/50",
-                              selectedRegionId === country.id && "bg-accent"
-                            )}
-                          >
-                            <div className="flex items-center gap-2 w-full">
-                              {selectedRegionId === country.id && (
-                                <Check className="h-4 w-4 text-primary shrink-0" />
-                              )}
-                              <span className="font-medium text-left flex-1">{country.name}</span>
-                              <Badge variant="secondary" className="text-xs">
-                                {counties.length}
-                              </Badge>
-                            </div>
-                          </Button>
-                          {/* Accordion trigger - uses built-in chevron */}
-                          <AccordionTrigger className="px-3 py-2 hover:no-underline hover:bg-accent/50" />
-                        </div>
-
-                        {/* Counties List */}
-                        <AccordionContent className="pb-0">
-                          <div className="border-l-2 ml-3 pl-3 space-y-0.5 pb-1">
-                            {counties.map((county) => (
-                              <Button
-                                key={county.id}
-                                variant="ghost"
-                                onClick={() => handleRegionSelect(county.id)}
-                                className={cn(
-                                  "w-full justify-start h-auto py-1.5 px-2 text-sm hover:bg-accent/50",
-                                  selectedRegionId === county.id && "bg-accent"
-                                )}
-                              >
-                                <div className="flex items-center gap-2 w-full">
-                                  {selectedRegionId === county.id && (
-                                    <Check className="h-3 w-3 text-primary shrink-0" />
-                                  )}
-                                  <span className="text-left flex-1">{county.name}</span>
-                                </div>
-                              </Button>
-                            ))}
-                          </div>
-                        </AccordionContent>
-                      </>
-                    ) : (
-                      /* Country without counties - just a button */
+        ) : (
+          <Accordion type="multiple" className="w-full p-2">
+            {filteredGroups.map(({ country, counties }) => (
+              <AccordionItem key={country.id} value={`country-${country.id}`} className="border-0">
+                {counties.length > 0 ? (
+                  <>
+                    {/* Country row - split into selection button and accordion trigger */}
+                    <div className="flex items-center">
+                      {/* Country selection button */}
                       <Button
                         variant="ghost"
                         onClick={() => handleRegionSelect(country.id)}
                         className={cn(
-                          "w-full justify-start h-auto py-2 px-3 rounded-none hover:bg-accent/50",
+                          "flex-1 justify-start h-auto py-2 px-3 rounded-none hover:bg-accent/50",
                           selectedRegionId === country.id && "bg-accent"
                         )}
                       >
@@ -192,16 +133,107 @@ export function HierarchicalRegionSelect({
                             <Check className="h-4 w-4 text-primary shrink-0" />
                           )}
                           <span className="font-medium text-left flex-1">{country.name}</span>
+                          <Badge variant="secondary" className="text-xs">
+                            {counties.length}
+                          </Badge>
                         </div>
                       </Button>
+                      {/* Accordion trigger - uses built-in chevron */}
+                      <AccordionTrigger className="px-3 py-2 hover:no-underline hover:bg-accent/50" />
+                    </div>
+
+                    {/* Counties List */}
+                    <AccordionContent className="pb-0">
+                      <div className="border-l-2 ml-3 pl-3 space-y-0.5 pb-1">
+                        {counties.map((county) => (
+                          <Button
+                            key={county.id}
+                            variant="ghost"
+                            onClick={() => handleRegionSelect(county.id)}
+                            className={cn(
+                              "w-full justify-start h-auto py-1.5 px-2 text-sm hover:bg-accent/50",
+                              selectedRegionId === county.id && "bg-accent"
+                            )}
+                          >
+                            <div className="flex items-center gap-2 w-full">
+                              {selectedRegionId === county.id && (
+                                <Check className="h-3 w-3 text-primary shrink-0" />
+                              )}
+                              <span className="text-left flex-1">{county.name}</span>
+                            </div>
+                          </Button>
+                        ))}
+                      </div>
+                    </AccordionContent>
+                  </>
+                ) : (
+                  /* Country without counties - just a button */
+                  <Button
+                    variant="ghost"
+                    onClick={() => handleRegionSelect(country.id)}
+                    className={cn(
+                      "w-full justify-start h-auto py-2 px-3 rounded-none hover:bg-accent/50",
+                      selectedRegionId === country.id && "bg-accent"
                     )}
-                  </AccordionItem>
-                ))}
-              </Accordion>
-            )}
-          </div>
-        </div>
-      )}
+                  >
+                    <div className="flex items-center gap-2 w-full">
+                      {selectedRegionId === country.id && (
+                        <Check className="h-4 w-4 text-primary shrink-0" />
+                      )}
+                      <span className="font-medium text-left flex-1">{country.name}</span>
+                    </div>
+                  </Button>
+                )}
+              </AccordionItem>
+            ))}
+          </Accordion>
+        )}
+      </div>
+    </div>
+  )
+
+  // Trigger button component (reused by both variants)
+  const triggerButton = (
+    <Button
+      variant="outline"
+      onClick={() => setIsExpanded(!isExpanded)}
+      className="w-full h-10 px-4 border rounded-lg justify-between hover:bg-accent/50"
+    >
+      <span className="text-sm font-medium text-foreground">Region</span>
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground truncate">{displayValue}</span>
+        <ChevronDown className={cn(
+          "h-4 w-4 shrink-0 opacity-50 transition-transform",
+          isExpanded && "rotate-180"
+        )} />
+      </div>
+    </Button>
+  )
+
+  // Render based on variant
+  if (variant === 'popover') {
+    return (
+      <Popover open={isExpanded} onOpenChange={setIsExpanded}>
+        <PopoverTrigger asChild className={className}>
+          {triggerButton}
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-[320px] p-0 border-0"
+          align="start"
+          side="bottom"
+          sideOffset={4}
+        >
+          {dropdownContent}
+        </PopoverContent>
+      </Popover>
+    )
+  }
+
+  // Default inline variant
+  return (
+    <div className={cn("space-y-2", className)}>
+      {triggerButton}
+      {isExpanded && dropdownContent}
     </div>
   )
 }

--- a/src/components/filters/map-filter-bar.tsx
+++ b/src/components/filters/map-filter-bar.tsx
@@ -74,61 +74,67 @@ export function MapFilterBar({
   }
 
   return (
-    <div className={`flex items-center gap-2 flex-wrap ${className}`}>
-      {/* Region Select - Compact */}
-      <div className="min-w-[200px] bg-background/95 backdrop-blur-sm rounded-lg shadow-lg">
-        <HierarchicalRegionSelect
-          regions={filterOptions.regions}
-          selectedRegionId={filters.region.selectedRegionId}
-          onRegionChange={handleRegionChange}
-          placeholder="All regions"
-          className="w-full"
-        />
-      </div>
-
-      {/* Year Picker - Compact */}
-      <div className="min-w-[140px] bg-background/95 backdrop-blur-sm rounded-lg shadow-lg">
-        <YearRangePicker
-          value={filters.yearRange}
-          onChange={handleYearRangeChange}
-          availableYears={filterOptions.availableYears}
-          className="w-full"
-        />
-      </div>
-
-      {/* Reset Button */}
-      {hasActiveFilters && (
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleResetFilters}
-          className="h-10 bg-background/95 backdrop-blur-sm shadow-lg"
-          aria-label="Reset all filters"
-        >
-          <RotateCcw className="h-4 w-4 mr-2" />
-          Reset
-        </Button>
-      )}
-
-      {/* Active Filters Summary */}
-      {hasActiveFilters && (
-        <div className="flex items-center gap-2 flex-wrap bg-background/95 backdrop-blur-sm rounded-lg shadow-lg px-3 py-2 border border-primary/20">
-          <Info className="h-4 w-4 text-primary" />
-          <span className="text-sm font-medium">Active:</span>
-          {filters.region.selectedRegionId && filters.region.selectedRegionId !== 1 && (
-            <Badge variant="secondary" className="text-xs">
-              {filterOptions.regions.find(r =>
-                r.id === filters.region.selectedRegionId
-              )?.name}
-            </Badge>
-          )}
-          {filters.yearRange.startYear !== filterOptions.availableYears.max && (
-            <Badge variant="secondary" className="text-xs">
-              {filters.yearRange.startYear}
-            </Badge>
-          )}
+    <div className={`bg-background/95 backdrop-blur-sm rounded-lg shadow-lg border p-2 ${className}`}>
+      <div className="flex items-center gap-2">
+        {/* Region Select - Fixed Width */}
+        <div className="w-[240px] shrink-0">
+          <HierarchicalRegionSelect
+            regions={filterOptions.regions}
+            selectedRegionId={filters.region.selectedRegionId}
+            onRegionChange={handleRegionChange}
+            placeholder="All regions"
+            variant="popover"
+            className="w-full"
+          />
         </div>
-      )}
+
+        {/* Year Picker - Fixed Width */}
+        <div className="w-[160px] shrink-0">
+          <YearRangePicker
+            value={filters.yearRange}
+            onChange={handleYearRangeChange}
+            availableYears={filterOptions.availableYears}
+            className="w-full"
+          />
+        </div>
+
+        {/* Reset Button */}
+        {hasActiveFilters && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleResetFilters}
+            className="h-10 shrink-0"
+            aria-label="Reset all filters"
+          >
+            <RotateCcw className="h-4 w-4 mr-2" />
+            Reset
+          </Button>
+        )}
+
+        {/* Active Filters Badge */}
+        {hasActiveFilters && (
+          <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-primary/10 border border-primary/20 shrink-0">
+            <Info className="h-4 w-4 text-primary shrink-0" />
+            <span className="text-xs font-medium text-primary">
+              {filters.region.selectedRegionId && filters.region.selectedRegionId !== 1 && (
+                <span>
+                  {filterOptions.regions.find(r =>
+                    r.id === filters.region.selectedRegionId
+                  )?.name}
+                </span>
+              )}
+              {filters.region.selectedRegionId && filters.region.selectedRegionId !== 1 &&
+               filters.yearRange.startYear !== filterOptions.availableYears.max && (
+                <span> • </span>
+              )}
+              {filters.yearRange.startYear !== filterOptions.availableYears.max && (
+                <span>{filters.yearRange.startYear}</span>
+              )}
+            </span>
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/filters/mobile-filter-bar.tsx
+++ b/src/components/filters/mobile-filter-bar.tsx
@@ -258,6 +258,7 @@ export function MobileFilterBar({
                     region: { selectedRegionId: regionId }
                   })
                 }
+                variant="inline"
                 className="w-full"
               />
 


### PR DESCRIPTION
- Add variant prop to HierarchicalRegionSelect ('inline' | 'popover')
- Desktop: Use popover variant to prevent layout shifts when expanding
- Desktop: Apply fixed widths (240px region, 160px year) to prevent wrapping
- Desktop: Unified container design with single background/border
- Desktop: More compact active filter badge display
- Mobile: Explicitly use inline variant, no functional changes
- Prevents region dropdown from pushing year filter when expanded

This fixes the issue where expanding countries in the region filter would cause the container to grow wider and push other filter elements.